### PR TITLE
[Feature]: Set Locale and Currency by Service Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ A regra para dinheiro aceita dois parâmetros, a moeda e a localicação. Utiliz
     ],
 ```
 
+Caso você precise verificar o formato do dinheiro conforme alguma regra em específica, você pode setar os callbacks no seu AppServiceProvider:
+
+```php
+    Money::setLocaleCallback(function ($default) {
+        return Auth::user()?->locale ?? $default;
+    });
+
+    Money::setCurrencyCallback(function ($default) {
+        return Auth::user()?->currency ?? $default;
+    });
+```
+
 Qualquer melhoria ou correção, poderá abrir um PR ou Issue.
 
 ## 🚀 Obrigado!

--- a/src/Rules/CNPJ.php
+++ b/src/Rules/CNPJ.php
@@ -59,12 +59,4 @@ class CNPJ implements Rule
 
         return true;
     }
-
-    /**
-     * Check if the parameters has the format.
-     */
-    private function hasFormat(): bool
-    {
-        return in_array('format', $this->parameters, true);
-    }
 }

--- a/src/Rules/CPF.php
+++ b/src/Rules/CPF.php
@@ -55,12 +55,4 @@ class CPF implements Rule
 
         return true;
     }
-
-    /**
-     * Check if the parameters has the format.
-     */
-    private function hasFormat(): bool
-    {
-        return in_array('format', $this->parameters, true);
-    }
 }

--- a/src/Rules/PIS.php
+++ b/src/Rules/PIS.php
@@ -53,12 +53,4 @@ class PIS implements Rule
 
         return (int) $p[10] === ($mod < 2 ? 0 : 11 - $mod);
     }
-
-    /**
-     * Check if the parameters has the format.
-     */
-    private function hasFormat(): bool
-    {
-        return in_array('format', $this->parameters, true);
-    }
 }

--- a/src/Support/Macros.php
+++ b/src/Support/Macros.php
@@ -21,10 +21,10 @@ class Macros
         });
 
         Str::macro('money', function (mixed $value): mixed {
-            return ltrim(preg_replace('/[^0-9]/', '', $value), '0');
+            return ltrim(self::onlyNumbers($value), '0');
         });
 
-        Str::macro('moneyValue', function (mixed $value): mixed {
+        Str::macro('moneyValue', function (mixed $value): float {
             return (int) self::money($value) / 100;
         });
 

--- a/src/Support/Macros.php
+++ b/src/Support/Macros.php
@@ -24,6 +24,10 @@ class Macros
             return ltrim(preg_replace('/[^0-9]/', '', $value), '0');
         });
 
+        Str::macro('moneyValue', function (mixed $value): mixed {
+            return (int) self::money($value) / 100;
+        });
+
         /**
          * Rules
          */

--- a/src/Traits/WithParameters.php
+++ b/src/Traits/WithParameters.php
@@ -10,6 +10,14 @@ trait WithParameters
     protected array $parameters = [];
 
     /**
+     * Check if the parameters has the format.
+     */
+    protected function hasFormat(): bool
+    {
+        return in_array('format', $this->parameters, true);
+    }
+
+    /**
      * Set the format in the parameters.
      */
     public function format(bool $format = true): static


### PR DESCRIPTION
You can create callback functions to set locale and currency in Money rule. Example:

In your AppServiceProvider.

```
Money::setLocaleCallback(function ($default) {
    return Auth::user()?->locale ?? $default;
});

Money::setCurrencyCallback(function ($default) {
    return Auth::user()?->currency ?? $default;
});
```